### PR TITLE
OMOP RxNorm Ingest

### DIFF
--- a/io/input/prefixes.csv
+++ b/io/input/prefixes.csv
@@ -230,3 +230,7 @@ OMIM,https://omim.org/entry/
 Orphanet,http://www.orpha.net/ORDO/Orphanet_
 N3C,http://purl.obolibrary.org/obo/N3C_
 OMOP,https://athena.ohdsi.org/search-terms/terms/
+cpont,https://w3id.org/cpont/
+omoprel,https://w3id.org/cpont/omop/relations/
+omoptype,https://w3id.org/cpont/omop/types/
+omopclass,https://w3id.org/cpont/omop/classes/

--- a/io/input/yarrrml_config.yaml
+++ b/io/input/yarrrml_config.yaml
@@ -230,3 +230,7 @@ prefixes:
   Orphanet: "http://www.orpha.net/ORDO/Orphanet_"
   N3C: "http://purl.obolibrary.org/obo/N3C_"
   OMOP: "https://athena.ohdsi.org/search-terms/terms/"
+  cpont: "https://w3id.org/cpont/"
+  omoprel: "https://w3id.org/cpont/omop/relations/"
+  omoptype: "https://w3id.org/cpont/omop/types/"
+  omopclass: "https://w3id.org/cpont/omop/classes/"

--- a/n3c_owl_ingest/__init__.py
+++ b/n3c_owl_ingest/__init__.py
@@ -1,2 +1,2 @@
 """N3C OMOP to OWL"""
-from n3c_owl_ingest.n3c_owl_ingest import run_ingest
+from n3c_owl_ingest.n3c_owl_ingest import main_ingest

--- a/n3c_owl_ingest/__main__.py
+++ b/n3c_owl_ingest/__main__.py
@@ -1,6 +1,6 @@
 """N3C OMOP to OWL"""
-from n3c_owl_ingest.n3c_owl_ingest import run_ingest
+from n3c_owl_ingest.n3c_owl_ingest import main_ingest
 
 
 if __name__ == '__main__':
-    run_ingest()
+    main_ingest()


### PR DESCRIPTION
OMOP RxNorm Ingest
    - Add: Specific logic for handling when 'output_type' == 'RxNorm'
    - Bugfix: Previous RxNorm output from 'all-split' output-type did not have all of the concepts or relationships needed.

General
    - Add: cli(): Command line interface. Has options to run output-type as 'all-split', 'all-merged', or 'rxnorm'. Can also specify paths to CSVs.
    - Rename: run_ingest() -> main_ingest()
    - Update: Can now handle predicates other than Subsumes
    - Update: Now automatically converts to SemanticSQL
    - Update: Optional caching
